### PR TITLE
Added clickable titles in report

### DIFF
--- a/layout/tudelft-report.cls
+++ b/layout/tudelft-report.cls
@@ -224,3 +224,37 @@
     \end{tikzpicture}
     \newpage
 }
+
+\makeatletter
+\let\hyperchapter\chapter
+\def\chapter{\@ifstar\starchapter\mychapter}
+\def\starchapter{\hyperchapter*}
+\newcommand{\mychapter}[2][\@empty]
+{\ifx#1\@empty \hyperchapter[#2]{\hyperlink{toc.chapter.\thechapter}{#2}}
+ \else \hyperchapter[#1]{\hyperlink{toc.chapter.\thechapter}{#2}}
+ \fi}
+
+\let\hypersection\section
+\def\section{\@ifstar\starsection\mysection}
+\def\starsection{\hypersection*}
+\newcommand{\mysection}[2][\@empty]
+{\ifx#1\@empty \hypersection[#2]{\hyperlink{toc.section.\thesection}{#2}}
+ \else \hypersecton[#1]{\hyperlink{toc.section.\thesection}{#2}}
+ \fi}
+ 
+\let\hypersubsection\subsection
+\def\subsection{\@ifstar\starsubsection\mysubsection}
+\def\starsubsection{\hypersubsection*}
+\newcommand{\mysubsection}[2][\@empty]
+{\ifx#1\@empty \hypersubsection[#2]{\hyperlink{toc.subsection.\thesubsection}{#2}}
+ \else \hypersecton[#1]{\hyperlink{toc.subsection.\thesubsection}{#2}}
+ \fi}
+ 
+\let\hypersubsubsection\subsubsection
+\def\subsubsection{\@ifstar\starsubsubsection\mysubsubsection}
+\def\starsubsubsection{\hypersubsubsection*}
+\newcommand{\mysubsubsection}[2][\@empty]
+{\ifx#1\@empty \hypersubsubsection[#2]{\hyperlink{toc.subsubsection.\thesubsubsection}{#2}}
+ \else \hypersecton[#1]{\hyperlink{toc.subsubsection.\thesubsubsection}{#2}}
+ \fi}
+\makeatother

--- a/report.tex
+++ b/report.tex
@@ -32,6 +32,8 @@
 
 \input{summary}
 
+\let\hypercontentsline=\contentsline
+\renewcommand{\contentsline}[4]{\hypertarget{toc.#4}{}\hypercontentsline{#1}{#2}{#3}{#4}}
 \tableofcontents
 
 %% List of abbreviations, symbols, figures and tables


### PR DESCRIPTION
This addition enables chapters, sections, subsections and subsubsections to be clickable so that, when you click on an item in the TOC, you can click on the respective title in the document to go back to the TOC, allowing you to easily go through the document without too much scrolling.

Two things that don't work at the moment:

1. Unnumbered titles don't work (you can't click on them to go back to the TOC)
2. Appendicex titles have the same issue